### PR TITLE
Using my-subscriptions-graphql insteadof my-orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2018-12-28
 ### Changed
 - Using queries from `vtex.my-subscriptions-graphql` instead of `vtex.my-orders`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "my-subscriptions",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "title": "MySubscriptions",
   "defaultLocale": "pt-BR",
   "description": "MySubscriptions app used used inside of the MyAccounts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.3",
+  "version": "0.3.0",
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "babylon": "^6.18.0",


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Using my-subscriptions-graphql insteadof my-orders

#### Related to:
- [my-subscription-graphql pr1](https://github.com/vtex/my-subscriptions-graphql/pull/1)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
