### PR TITLE
Fix: custom tax display

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.15.0] - 2023-05-15
+
 ### Fixed
 
 - Improve display of custom taxes in subscription `SummaryContent` component
@@ -209,6 +211,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1...HEAD
 [3.12.0]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.11.1...vtex.my-subscriptions@3.12.0
+[3.15.0]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...vtex.my-subscriptions@3.15.0
 [3.14.2]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...vtex.my-subscriptions@3.14.2
 [3.14.1]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.0...vtex.my-subscriptions@3.14.1
 [3.14.0]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1...vtex.my-subscriptions@3.14.0
@@ -216,3 +219,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [3.13.1-beta]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.0...vtex.my-subscriptions@3.13.1-beta
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...HEAD
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD
+
+
+[Unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.0...HEAD

--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve display of custom taxes in subscription `SummaryContent` component
+- Better handling for cases where a subscription may include SKUs that no longer exist (mostly relevant for QA accounts)
+
 ## [3.14.2] - 2023-05-11
 
 ### Fixed
@@ -210,6 +215,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [3.13.1]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1-beta...vtex.my-subscriptions@3.13.1
 [3.13.1-beta]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.0...vtex.my-subscriptions@3.13.1-beta
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...HEAD
-
-
-[Unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD
+[unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD

--- a/apps/vtex-my-subscriptions-3/manifest.json
+++ b/apps/vtex-my-subscriptions-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "my-subscriptions",
-  "version": "3.14.2",
+  "version": "3.15.0",
   "title": "MySubscriptions",
   "defaultLocale": "pt-BR",
   "description": "MySubscriptions app used used inside of the MyAccounts",

--- a/apps/vtex-my-subscriptions-3/react/components/List/Images.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/List/Images.tsx
@@ -12,7 +12,7 @@ interface Props {
   skus: Array<{
     imageUrl: string
     productName: string
-  }>
+  }> | null
 }
 
 const iconSize = 17
@@ -57,15 +57,15 @@ function getParams(imagesLength: number) {
 }
 
 const SubscriptionImages: FunctionComponent<Props> = ({ skus }) => {
-  const params = getParams(skus.length)
+  const params = getParams(skus?.length ?? 0)
   return (
     <div className={CSS.subscriptionImageWrapper}>
       <Swiper {...params}>
-        {skus.map((sku, i) => (
+        {skus?.map((sku, i) => (
           <div key={i} className="swiper-slide center-all pa6 w-100">
             <ProductImage
-              imageUrl={sku.imageUrl}
-              productName={sku.productName}
+              imageUrl={sku?.imageUrl}
+              productName={sku?.productName}
             />
           </div>
         ))}

--- a/apps/vtex-my-subscriptions-3/react/components/SubscriptionName.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/SubscriptionName.tsx
@@ -22,15 +22,15 @@ const messages = defineMessages({
 export function getName(
   intl: InnerProps['intl'],
   name: string | null | undefined,
-  skus: Array<{ name: string }>
+  skus: Array<{ name: string }> | null
 ) {
   let content: string
   if (name) {
     content = name
-  } else if (skus.length === 1) {
+  } else if (skus?.length === 1 && skus[0]?.name) {
     content = skus[0].name
   } else {
-    content = intl.formatMessage(messages.title, { value: skus.length })
+    content = intl.formatMessage(messages.title, { value: skus?.length ?? 0 })
   }
 
   return content

--- a/apps/vtex-my-subscriptions-3/react/components/Summary/Content.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/Summary/Content.tsx
@@ -2,15 +2,42 @@ import React, { FunctionComponent } from 'react'
 import { FormattedNumber, FormattedMessage } from 'react-intl'
 import { Total } from 'vtex.subscriptions-graphql'
 import { TranslateTotalizer } from 'vtex.totalizer-translator'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [
+  'summaryRow',
+  'summaryItems',
+  'summaryDiscounts',
+  'summaryShipping',
+  'summaryTax',
+  'summaryInterest',
+  'summaryChange',
+  'summaryOther',
+  'summaryTotal',
+]
 
 const SummaryContent: FunctionComponent<Props> = ({ totals, currencyCode }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const taxTotals = totals.filter((total) =>
+    total.id.toLowerCase().includes('tax')
+  )
+  const nonTaxTotals = totals.filter(
+    (total) => !total.id.toLowerCase().includes('tax')
+  )
+
+  const totalTax = taxTotals?.reduce((price, total) => price + total.value, 0)
   const fullPrice = totals.reduce((price, total) => price + total.value, 0)
 
   return (
     <div className="t-body">
-      {totals?.map((total) => {
+      {nonTaxTotals?.map((total) => {
         return (
-          <div className="mb4 flex justify-between" key={total.id}>
+          <div
+            className={`mb4 flex justify-between ${handles.summaryRow} ${
+              handles[`summary${total.id}`] ?? handles.summaryOther
+            }`}
+            key={total.id}
+          >
             <span>
               <TranslateTotalizer id={total.id} nonStorePage />
             </span>
@@ -22,7 +49,23 @@ const SummaryContent: FunctionComponent<Props> = ({ totals, currencyCode }) => {
           </div>
         )
       })}
-      <div className="mt5 pt6 b--muted-4 bt flex justify-between b">
+      {totalTax > 0 && (
+        <div
+          className={`mb4 flex justify-between ${handles.summaryRow} ${handles.summaryTax}`}
+        >
+          <span>
+            <TranslateTotalizer id="Tax" nonStorePage />
+          </span>
+          <FormattedNumber
+            currency={currencyCode}
+            style="currency"
+            value={totalTax / 100}
+          />
+        </div>
+      )}
+      <div
+        className={`mt5 pt6 b--muted-4 bt flex justify-between b ${handles.summaryRow} ${handles.summaryTotal}`}
+      >
         <span>
           <FormattedMessage id="subscription.summary.totalValue" />{' '}
         </span>


### PR DESCRIPTION
#### What does this PR do?

For stores that use external tax integrations, the subscription summary currently looks like this:

![image](https://github.com/vtex/my-subscriptions/assets/6306265/abbd00cc-6836-4cc0-b741-f203227960ca)

This PR improves the appearance of such taxes, by consolidating them into a single line with the standard "taxes" label:

<img width="269" alt="image" src="https://github.com/vtex/my-subscriptions/assets/6306265/bfd20e91-5f17-494c-ac0b-16b4c3e36ed0">

Additionally, CSS handles have been added to each totalizer row. 

Finally, better null handling has been implemented so that subscription details can still be rendered if a subscription contains deleted SKUs (mostly relevant for QA accounts). 

#### How to test it? \*

New version linked here: https://arthur--beautycounterqa.myvtex.com/account
User credentials available upon request, DM me on Slack at `@arthur`