### PR TITLE
fix: :children_crossing: Fix subscription details initial scroll

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix when selecting subscription details scroll behavior
+
 ## [3.14.1] - 2023-04-10
 
 ### Fixed

--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.14.2] - 2023-05-11
+
 ### Fixed
 
 - Fix when selecting subscription details scroll behavior
@@ -202,8 +204,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1...HEAD
 [3.12.0]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.11.1...vtex.my-subscriptions@3.12.0
+[3.14.2]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...vtex.my-subscriptions@3.14.2
 [3.14.1]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.0...vtex.my-subscriptions@3.14.1
 [3.14.0]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1...vtex.my-subscriptions@3.14.0
 [3.13.1]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.1-beta...vtex.my-subscriptions@3.13.1
 [3.13.1-beta]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.13.0...vtex.my-subscriptions@3.13.1-beta
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...HEAD
+
+
+[Unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD

--- a/apps/vtex-my-subscriptions-3/manifest.json
+++ b/apps/vtex-my-subscriptions-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "my-subscriptions",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "title": "MySubscriptions",
   "defaultLocale": "pt-BR",
   "description": "MySubscriptions app used used inside of the MyAccounts",

--- a/apps/vtex-my-subscriptions-3/react/components/DetailsPage/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/DetailsPage/index.tsx
@@ -67,7 +67,7 @@ class SubscriptionsDetailsContainer extends Component<Props, State> {
   }
 
   public componentDidMount() {
-    goToElement({ id: DETAILS_ID, option: 'start' })
+    document.body.scrollIntoView(true)
   }
 
   private handleOpenHistory = () => this.setState({ displayHistory: true })


### PR DESCRIPTION


#### What does this PR do? \*
This PR fixes the scroll behavior when selecting subscription details

#### How to test it? \*

- Go to your user profile -> "My subscriptions"
- Select any subscription to see its details.
- Now you will see that the scroll will alway starts in the top of the page

#### Related to / Depends on \*
https://vtex.slack.com/archives/G016AGYHTV2/p1683135218435149
