### PR TITLE
Fixed a spanish translation for uniformity across other repositories

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Spanish translation.
+
 ## [3.15.0] - 2023-05-15
 
 ### Fixed

--- a/apps/vtex-my-subscriptions-3/messages/es.json
+++ b/apps/vtex-my-subscriptions-3/messages/es.json
@@ -110,7 +110,7 @@
   "display-payment.payment-error-message": "Tu método de pago no parece funcionar.",
   "summary.title": "Resumen",
   "summary.price-warning": "*Precios válidos hasta {day}",
-  "list-page.back": "Regreso",
+  "list-page.back": "Atrás",
   "list-page.create-subscriptions": "Suscripción nueva",
   "creation-page.title": "Suscripción nueva",
   "creation-page.back-button": "Todas las suscripciones",


### PR DESCRIPTION
#### What does this PR do? \*
It relates to task [LOC-11299](https://vtex-dev.atlassian.net/browse/LOC-11299). Fixes a Spanish string that is supposed to be "Atrás".


[LOC-11299]: https://vtex-dev.atlassian.net/browse/LOC-11299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ