### PR TITLE
fix subscription product image not being displayed

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+Fix subscription product image not being displayed
+
 ## [3.15.1] - 2023-06-20
 
 ### Added

--- a/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
@@ -19,7 +19,9 @@ class ProductImage extends PureComponent<Props> {
   }
 
   private handleStopLoading = () => {
-    setTimeout(() => this.setState({ isLoading: false }), 100)
+    setTimeout(() => {
+      this.setState({ isLoading: false })
+    }, 100)
   }
 
   private handleError = () => {
@@ -35,30 +37,28 @@ class ProductImage extends PureComponent<Props> {
     const displayPaceholder = isLoading || hasLoadError || !hasImage
     const displayImage = !hasLoadError && hasImage
 
+    // The events onLoad and onError not always are triggered
+    setTimeout(() => {
+      if(hasImage && isLoading) {
+        this.setState({ isLoading: false })
+      }
+    }, 100);
+
     return (
       <div
         className="flex items-center justify-center"
         style={isFixed ? { width, height } : { width: '100%', height: '100%' }}
       >
-        {displayPaceholder && <IconPlaceholder />}
         {displayImage && (
           <img
             className="w-100 h-100"
             src={fixImageUrl(imageUrl, width, height)}
             alt={productName}
-            style={{
-              // Fix blinking behavior
-              height: isLoading ? 0 : '100%',
-              transition: 'opacity 1s ease-in-out',
-              WebkitTransition: 'opacity 1s ease-in-out',
-              MozTransition: 'opacity 1s ease-in-out',
-              OTransition: 'opacity 1s ease-in-out',
-              opacity: isLoading ? 0 : 1,
-            }}
             onLoad={this.handleStopLoading}
             onError={this.handleError}
           />
         )}
+        {displayPaceholder && <IconPlaceholder />}
       </div>
     )
   }


### PR DESCRIPTION
#### What does this PR do? \*

Fix the product image not being displayed on the subscription detail page. Was inconsistent, displaying the placeholder even when returning the product image.

<img width="718" alt="Screenshot 2023-06-22 at 2 36 00 PM" src="https://github.com/vtex/my-subscriptions/assets/18540163/2ea1d861-7ba6-4f14-a6c4-cb861e1fc1e2">

#### How to test it? \*

- Log in with `` in [workspace](https://bcc33786--beautycounterqa.myvtex.com)
- [visit](https://bcc33786--beautycounterqa.myvtex.com/account#/subscriptions)

#### Related to / Depends on \*

<!--- Optional -->
