### PR TITLE
remove image transition

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Animation properties removal
+
 ## [3.15.3] - 2023-08-08
 
 ### Fixed
@@ -249,6 +253,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.1...HEAD
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.1...HEAD
-
-
-[Unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.3...HEAD
+[unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.3...HEAD

--- a/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
@@ -40,16 +40,6 @@ class ProductImage extends PureComponent<Props> {
             className="w-100 h-100"
             src={fixImageUrl(imageUrl, width, height)}
             alt={productName}
-            style={{
-              visibility: displayPlaceholder ? 'hidden' : 'visible',
-              // Fix blinking behavior
-              height: displayPlaceholder ? 0 : '100%',
-              transition: 'opacity 1s ease-in-out',
-              WebkitTransition: 'opacity 1s ease-in-out',
-              MozTransition: 'opacity 1s ease-in-out',
-              OTransition: 'opacity 1s ease-in-out',
-              opacity: displayPlaceholder ? 0 : 1,
-            }}
             onLoad={this.handleStopLoading}
             onError={this.handleError}
           />


### PR DESCRIPTION
#### What does this PR do? \*
I've identified an issue with the `onLoad` call in the image component, which is preventing the transition from the placeholder component to the actual image. It appears that the variable style props such as `visibility`, `height`, and `opacity` are affecting the functionality of the `onLoad` function, causing it not to execute. I conducted a test by temporarily removing these style properties, and the transition occurred as expected. This suggests a potential interference in the animation lifecycle that impacts the `onLoad` call, failing to set the `displayPlaceholder` prop to `false`, and leading to the reported problem.

#### How to test it? \*

https://wagnerlduarte--beautycounterqa.myvtex.com/account/?__bindingAddress=qa.beautycountertest.com/en-us#/subscriptions-new

![product image](https://github.com/vtex/my-subscriptions/assets/17439470/82e89c8e-616e-41d4-929f-4addd835f968)

