### PR TITLE
add react-image to control product image transaction

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add `react-image`
+
 ## [3.15.4] - 2023-08-17
 
 ### Fixed
@@ -257,6 +259,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.14.2...HEAD
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.1...HEAD
 [unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.3...HEAD
-
-
-[Unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.4...HEAD
+[unreleased]: https://github.com/vtex/my-subscriptions/compare/vtex.my-subscriptions@3.15.4...HEAD

--- a/apps/vtex-my-subscriptions-3/react/components/ProductImage/Image.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/ProductImage/Image.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useImage } from 'react-image'
+
+import IconPlaceholder from './IconPlaceholder'
+
+interface ImageProps {
+  src: string
+  productName: string
+}
+
+export const Image: React.FC<ImageProps> = ({ src, productName }) => {
+  const { src: srcImage, isLoading } = useImage({
+    srcList: src,
+    useSuspense: false,
+  })
+
+  return (
+    <>
+      {<IconPlaceholder />}
+      {
+        <img
+          className="w-100 h-100"
+          src={srcImage}
+          alt={productName}
+          style={{
+            transition: 'opacity 1s ease-in-out',
+            WebkitTransition: 'opacity 1s ease-in-out',
+            MozTransition: 'opacity 1s ease-in-out',
+            OTransition: 'opacity 1s ease-in-out',
+            opacity: isLoading ? 0 : 1,
+          }}
+        />
+      }
+    </>
+  )
+}

--- a/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/ProductImage/index.tsx
@@ -1,60 +1,36 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import { utils } from 'vtex.my-account-commons'
 
-import IconPlaceholder from './IconPlaceholder'
+import { Image } from './Image'
 
 const { fixImageUrl } = utils
-
-// eslint-disable-next-line react/prefer-stateless-function
-class ProductImage extends PureComponent<Props> {
-  public static defaultProps = {
-    width: 300,
-    height: 300,
-    isFixed: false,
-  }
-
-  public state = {
-    displayPlaceholder: true,
-  }
-
-  private handleStopLoading = () => {
-    this.setState({ displayPlaceholder: false })
-  }
-
-  private handleError = () => {
-    this.setState({ displayPlaceholder: true })
-  }
-
-  public render() {
-    const { productName, imageUrl, width, height, isFixed } = this.props
-    const { displayPlaceholder } = this.state
-
-    return (
-      <div
-        className="flex items-center justify-center"
-        style={isFixed ? { width, height } : { width: '100%', height: '100%' }}
-      >
-        {displayPlaceholder && <IconPlaceholder />}
-        {Boolean(imageUrl) && (
-          <img
-            className="w-100 h-100"
-            src={fixImageUrl(imageUrl, width, height)}
-            alt={productName}
-            onLoad={this.handleStopLoading}
-            onError={this.handleError}
-          />
-        )}
-      </div>
-    )
-  }
-}
 
 interface Props {
   productName: string
   imageUrl?: string
-  width: number
-  height: number
-  isFixed: boolean
+  width?: number
+  height?: number
+  isFixed?: boolean
+}
+
+const ProductImage: React.FC<Props> = ({
+  productName,
+  imageUrl,
+  width = 300,
+  height = 300,
+  isFixed = false,
+}: Props) => {
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={isFixed ? { width, height } : { width: '100%', height: '100%' }}
+    >
+      <Image
+        src={fixImageUrl(imageUrl, width, height)}
+        productName={productName}
+      />
+    </div>
+  )
 }
 
 export default ProductImage

--- a/apps/vtex-my-subscriptions-3/react/package.json
+++ b/apps/vtex-my-subscriptions-3/react/package.json
@@ -13,6 +13,7 @@
     "react-apollo": "3",
     "react-dom": "^16.13.1",
     "react-id-swiper": "^1.6.8",
+    "react-image": "^4.1.0",
     "react-infinite-scroller": "^1.2.4",
     "react-intl": "3",
     "recompose": "^0.30.0",

--- a/apps/vtex-my-subscriptions-3/react/yarn.lock
+++ b/apps/vtex-my-subscriptions-3/react/yarn.lock
@@ -4919,6 +4919,11 @@ react-id-swiper@^1.6.8:
     prop-types "^15.7.2"
     swiper "^4.4.6"
 
+react-image@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-image/-/react-image-4.1.0.tgz#92f2d4a809a178b3bf69acd7bad7da7aa5e7364c"
+  integrity sha512-qwPNlelQe9Zy14K2pGWSwoL+vHsAwmJKS6gkotekDgRpcnRuzXNap00GfibD3eEPYu3WCPlyIUUNzcyHOrLHjw==
+
 react-infinite-scroller@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz#f67eaec4940a4ce6417bebdd6e3433bfc38826e9"


### PR DESCRIPTION
#### What does this PR do? \*
Add [react-image](https://www.npmjs.com/package/react-image) library to control load image to improve animation callback

#### How to test it? \*

- Logged in with a user access the subscriptions page using this [link](https://wagnerlduarte--recorrenciacharlie.myvtex.com/account#/subscriptions)
- Create a new subscription with some products

#### Related to / Depends on \*
> Related to: https://github.com/vtex/my-subscriptions/pull/194

<!--- Optional -->
