### PR TITLE
Added CSS class to filter dropdown

### DIFF
--- a/apps/vtex-my-subscriptions-3/CHANGELOG.md
+++ b/apps/vtex-my-subscriptions-3/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added CSS class to filter dropdown
+
 ## [3.15.4] - 2023-08-17
 
 ### Fixed

--- a/apps/vtex-my-subscriptions-3/react/components/List/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/List/index.tsx
@@ -130,7 +130,7 @@ class SubscriptionsListContainer extends Component<
           </Header>
         </div>
         <div className="pa5 pa7-ns">
-          <div className="w5 mb7">
+          <div className="w5 mb7 subscription__filter-dropdown-wrapper">
             <Dropdown
               label={filterLabel}
               size="large"

--- a/apps/vtex-my-subscriptions-3/react/components/List/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/List/index.tsx
@@ -130,7 +130,7 @@ class SubscriptionsListContainer extends Component<
           </Header>
         </div>
         <div className="pa5 pa7-ns">
-          <div className="w5 mb7 subscription__filter-dropdown-wrapper">
+          <div className="subscription__filter-dropdown-wrapper w5 mb7">
             <Dropdown
               label={filterLabel}
               size="large"


### PR DESCRIPTION
#### What does this PR do? \*
Add class name to dropdown wrapper
<img width="431" alt="image" src="https://github.com/vtex/my-subscriptions/assets/3091668/d8469a1e-0946-44a1-bcf7-ed4696e67d79">

#### How to test it? \*

- Place an subscription order in https://jamal--beautycounterqa.myvtex.com/?__bindingAddress=qa.beautycountertest.com/en-us with any user. You can this item, for example: https://jamal--beautycounterqa.myvtex.com/skin-twin-creamy-concealer/p?__bindingAddress=qa.beautycountertest.com/en-us&skuId=100001320
<img width="337" alt="image" src="https://github.com/vtex/my-subscriptions/assets/3091668/f27dceed-14af-47fe-9e99-bd2afa23fcfe">

- Log in with your user in [workspace](https://jamal--beautycounterqa.myvtex.com/)
- [visit](https://jamal--beautycounterqa.myvtex.com/account?__bindingAddress=qa.beautycountertest.com/en-us#/subscriptions)

#### Related to / Depends on \*

<!--- Optional -->
