### PR TITLE
Add timeout to batch modal update response

### DIFF
--- a/apps/vtex-my-subscriptions-3/react/components/DetailsPage/BatchModal.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/DetailsPage/BatchModal.tsx
@@ -175,24 +175,30 @@ class BatchModal extends Component<Props, State> {
     }
 
     promises?.then(() => {
-      const displayError = this.state.completed.length !== selectedIds.length
+      // timeout added due to state not update instantaneously
+      setTimeout(() => {
+        // filter only unique completed ids
+        const uniqueCompletedIds = this.state.completed.filter((completed, index) => this.state.completed.indexOf(completed) === index);
 
-      if (!displayError) {
-        showToast({ message: intl.formatMessage(messages.success) })
-        onClose()
-      } else {
-        this.setState((finalState) => {
-          finalState.completed.map((id) => delete finalState.selectionItems[id])
+        const displayError = uniqueCompletedIds.length !== selectedIds.length
 
-          return {
-            selectionItems: finalState.selectionItems,
-            loading: false,
-            // If some subscription isn't on the finalState
-            // it means that some error has ocurred
-            displayError,
-          }
-        })
-      }
+        if (!displayError) {
+          showToast({ message: intl.formatMessage(messages.success) })
+          onClose()
+        } else {
+          this.setState((finalState) => {
+            finalState.completed.map((id) => delete finalState.selectionItems[id])
+
+            return {
+              selectionItems: finalState.selectionItems,
+              loading: false,
+              // If some subscription isn't on the finalState
+              // it means that some error has ocurred
+              displayError,
+            }
+          })
+        }
+      }, 100)
     })
   }
 


### PR DESCRIPTION
#### What does this PR do? \*
Add a timeout to handle state after update. Without it the error modal is displayed even when all requests went ok.

Without timeout:
<img width="822" alt="Screenshot 2023-09-04 at 15 04 11" src="https://github.com/vtex/my-subscriptions/assets/3091668/c293cbf8-d3f6-4b98-8de2-ac36afe749f5">
<img width="818" alt="Screenshot 2023-09-04 at 15 04 17" src="https://github.com/vtex/my-subscriptions/assets/3091668/25efc390-44b6-4c29-8852-3e75529608b4">


#### How to test it? \*

- Log in with any user in [workspace](https://jamal--beautycounterqa.myvtex.com/)
- [visit](https://jamal--beautycounterqa.myvtex.com/)
- Create two orders with subscriptions.
- Go to subscriptions page and change the address or the payment method for one of them. Wait for the batch modal appears, select all and save.

#### Related to / Depends on \*

<!--- Optional -->
