### PR TITLE
fix(datepicker): apply correct locale setting

### DIFF
--- a/apps/vtex-my-subscriptions-3/react/components/CreationPage/FrequencySection/index.tsx
+++ b/apps/vtex-my-subscriptions-3/react/components/CreationPage/FrequencySection/index.tsx
@@ -61,6 +61,7 @@ const FrequencySection: FunctionComponent<Props> = ({ frequencies }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
   const { locale, formatMessage } = useIntl()
+  const localeDatePicker = locale.split('-')[0]
 
   return (
     <div className={`${handles.frequencyWrapper} flex flex-row-ns flex-column`}>
@@ -123,7 +124,7 @@ const FrequencySection: FunctionComponent<Props> = ({ frequencies }) => {
                   : MONTH_OPTIONS[27]
               )
           }}
-          locale={locale}
+          locale={localeDatePicker}
         />
         <div className={`${handles.addExpirationDate} pt6`}>
           <Checkbox
@@ -153,7 +154,7 @@ const FrequencySection: FunctionComponent<Props> = ({ frequencies }) => {
                 days: 1,
               })}
               onChange={expirationDateHelper.setValue}
-              locale={locale}
+              locale={localeDatePicker}
             />
           </div>
         )}


### PR DESCRIPTION
Ensured that the correct locale is applied to all datepickers across the application, resolving localization issues.

#### What does this PR do? \*
Fixed datepickers date format taking the correct locale

#### How to test it? \*

- Log in with  your user in [substest--cemacogt.myvtex.com](https://substest--cemacogt.myvtex.com/account#/subscriptions-new)
- [visit](https://substest--cemacogt.myvtex.com/account#/subscriptions-new)
- When adding a new subscription, the date format appears correctly in the datepicker DD/MM/YYYY taking the locale as "es" instead of "es-GT"

#### Related to / Depends on \*

<!--- Optional -->
